### PR TITLE
Renamed to grunt-featureswitch-strip

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,6 @@
 /*
- * grunt-featureswitch-html
- * https://github.com/hal313/grunt-featureswitch-html
+ * grunt-featureswitch-strip
+ * https://github.com/hal313/grunt-featureswitch-strip
  *
  * Copyright (c) 2016 John Ghidiu
  * Licensed under the MIT license.
@@ -11,95 +11,95 @@
 module.exports = function(grunt) {
 
 
-  // Project configuration.
-  grunt.initConfig({
-    jshint: {
-      all: [
-        'Gruntfile.js',
-        'tasks/*.js',
-        '<%= nodeunit.tests %>'
-      ],
-      options: {
-        jshintrc: '.jshintrc'
-      }
-    },
-
-    // Before generating any new files, remove any previously-created files.
-    clean: {
-      tests: ['tmp']
-    },
-
-    // Configuration to be run (and then tested).
-    'featureswitch-html': {
-
-      // Simple test of the HTML feature switch
-      'simple-html-only-disabled': {
-        features: {
-          f1: false
+    // Project configuration.
+    grunt.initConfig({
+        jshint: {
+            all: [
+                'Gruntfile.js',
+                'tasks/*.js',
+                '<%= nodeunit.tests %>'
+            ],
+            options: {
+                jshintrc: '.jshintrc'
+            }
         },
-        files: [{
-          src: ['test/source/simple.html'],
-          dest: 'test/actual/simple-html-only-disabled.html'
-        }]
-      },
 
-      'simple-html-only-enabled': {
-        features: {
-          f1: true
+        // Before generating any new files, remove any previously-created files.
+        clean: {
+            tests: ['tmp']
         },
-        files: [{
-          src: ['test/source/simple.html'],
-          dest: 'test/actual/simple-html-only-enabled.html'
-        }]
-      },
 
-      'simple-js-only-disabled': {
-        options: {
-          includeJS: true
+        // Configuration to be run (and then tested).
+        'featureswitch-strip': {
+
+            // Simple test of the HTML feature switch
+            'simple-html-only-disabled': {
+                features: {
+                    f1: false
+                },
+                files: [{
+                    src: ['test/source/simple.html'],
+                    dest: 'test/actual/simple-html-only-disabled.html'
+                }]
+            },
+
+            'simple-html-only-enabled': {
+                features: {
+                    f1: true
+                },
+                files: [{
+                    src: ['test/source/simple.html'],
+                    dest: 'test/actual/simple-html-only-enabled.html'
+                }]
+            },
+
+            'simple-js-only-disabled': {
+                options: {
+                    includeJS: true
+                },
+                features: {
+                    f1: false
+                },
+                files: [{
+                    src: ['test/source/simple.js'],
+                    dest: 'test/actual/simple-js-only-disabled.js'
+                }]
+            },
+
+            'simple-js-only-enabled': {
+                options: {
+                    includeJS: true
+                },
+                features: {
+                    f1: true
+                },
+                files: [{
+                    src: ['test/source/simple.js'],
+                    dest: 'test/actual/simple-js-only-enabled.js'
+                }]
+            }
         },
-        features: {
-          f1: false
-        },
-        files: [{
-          src: ['test/source/simple.js'],
-          dest: 'test/actual/simple-js-only-disabled.js'
-        }]
-      },
 
-      'simple-js-only-enabled': {
-        options: {
-          includeJS: true
-        },
-        features: {
-          f1: true
-        },
-        files: [{
-          src: ['test/source/simple.js'],
-          dest: 'test/actual/simple-js-only-enabled.js'
-        }]
-      }
-    },
+        // Unit tests.
+        nodeunit: {
+            tests: ['test/*_test.js']
+        }
 
-    // Unit tests.
-    nodeunit: {
-      tests: ['test/*_test.js']
-    }
+    });
 
-  });
+    // Actually load this plugin's task(s).
+    grunt.loadTasks('tasks');
 
-  // Actually load this plugin's task(s).
-  grunt.loadTasks('tasks');
+    // These plugins provide necessary tasks.
+    grunt.loadNpmTasks('grunt-contrib-jshint');
+    grunt.loadNpmTasks('grunt-contrib-clean');
+    grunt.loadNpmTasks('grunt-contrib-nodeunit');
 
-  // These plugins provide necessary tasks.
-  grunt.loadNpmTasks('grunt-contrib-jshint');
-  grunt.loadNpmTasks('grunt-contrib-clean');
-  grunt.loadNpmTasks('grunt-contrib-nodeunit');
+    // Whenever the "test" task is run, first clean the "tmp" dir, then run this
+    // plugin's task(s), then test the result.
+    grunt.registerTask('test', ['clean', 'featureswitch-strip', 'nodeunit']);
 
-  // Whenever the "test" task is run, first clean the "tmp" dir, then run this
-  // plugin's task(s), then test the result.
-  grunt.registerTask('test', ['clean', 'featureswitch-html', 'nodeunit']);
-
-  // By default, lint and run all tests.
-  grunt.registerTask('default', ['jshint', 'test']);
+    // By default, lint and run all tests.
+    grunt.registerTask('default', ['jshint', 'test']);
 
 };

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# grunt-featureswitch-html
+# grunt-featureswitch-strip
 
-> Removes disabled features from HTML
+>Strips disabled features from files as a grunt task. The features are described within specialized HTML or Javascript comments.
 
 ## Getting Started
 This plugin requires Grunt `~0.4.5`
@@ -8,25 +8,26 @@ This plugin requires Grunt `~0.4.5`
 If you haven't used [Grunt](http://gruntjs.com/) before, be sure to check out the [Getting Started](http://gruntjs.com/getting-started) guide, as it explains how to create a [Gruntfile](http://gruntjs.com/sample-gruntfile) as well as install and use Grunt plugins. Once you're familiar with that process, you may install this plugin with this command:
 
 ```shell
-npm install grunt-featureswitch-html --save-dev
+npm install grunt-featureswitch-strip --save-dev
 ```
 
-Once the plugin has been installed, it may be enabled inside your Gruntfile with this line of JavaScript:
+Once the plugin has been installed, it may be enabled inside your Gruntfile with this line of Javascript:
 
 ```js
-grunt.loadNpmTasks('grunt-featureswitch-html');
+grunt.loadNpmTasks('grunt-featureswitch-strip');
 ```
 
-## The "featureswitch-html" task
+## The "featureswitch-strip" task
 
 ### Overview
-In your project's Gruntfile, add a section named `featureswitch-html` to the data object passed into `grunt.initConfig()`.
+In your project's Gruntfile, add a section named `featureswitch-strip` to the data object passed into `grunt.initConfig()`.
 
 ```js
 grunt.initConfig({
-  featureswitch-html: {
+  featureswitch-strip: {
     options: {
-        includeJS: false // Include JavaScript files
+        includeHTML: true, // Remove features specified with HTML comments (default true)
+        includeJS: false   // Remove features specified with Javascript comments (default false)
     },
     your_target: {
       // Target-specific file lists and/or options go here.
@@ -41,22 +42,42 @@ grunt.initConfig({
 Type: `boolean`
 Default value: `false`
 
-Includes the removal of code from JavaScript files.
+Remove features specified with Javascript comments. Such a feature may look like:
+```js
+    var username = window.prompt('Username');
+    // FEATURE.start(capitalizeInput) //
+    username = username.toUpperCase();
+    // FEATURE.end(capitalizeInput) //
+```
+Note that the parser *requires* the trailing ```//``` on the ```// FEATURE.end(...) //``` declaration; this ensures that the parser removes any trailing characters and does not leave unwanted characters in the output.
 
 #### options.includeHTML
 Type: `boolean`
 Default value: `true`
 
-Includes the removal of code from HTML files.
+Remove features specified with HTML comments. HTML features are specified like:
+```html
+<h1>Frankenstein<h1>
+<!-- FEATURE.start(showSubTitle) -->
+<h2>or, The Modern Prometheus</h2>
+<!-- FEATURE.end(showSubTitle) -->
+```
+Note that the parser *requires* the trailing ```-->``` on the ```<!-- FEATURE.end(...) -->``` declaration; this ensures that the parser removes any trailing characters and does not leave unwanted characters in the output.
 
 ### Usage Examples
 
 #### Default Options
-In this example, the file index.html is stripped of any feature switch comments.
+In this example, the file index.html is stripped of any feature switch comments, both HTML and Javascript.
 
 ```js
 grunt.initConfig({
-  featureswitch-html: {
+  'featureswitch-strip': {
+    options: {
+      includeJS: true
+    },
+    features: {
+      f1: false
+    },
     files: {
       src: ['app/index.html'],
       dest: 'dist.html'
@@ -67,6 +88,3 @@ grunt.initConfig({
 
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).
-
-## Release History
-_(Nothing yet)_

--- a/package.json
+++ b/package.json
@@ -1,23 +1,23 @@
 {
-  "name": "grunt-featureswitch-html",
-  "description": "Removes disabled features from HTML",
-  "version": "0.1.0",
-  "homepage": "https://github.com/hal313/grunt-featureswitch-html",
+  "name": "grunt-featureswitch-strip",
+  "description": "Removes disabled features from HTML files",
+  "version": "1.0.0",
+  "homepage": "https://github.com/hal313/grunt-featureswitch-strip",
   "author": {
     "name": "John Ghidiu",
     "email": "john-github@rmdashrf.org"
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/hal313/grunt-featureswitch-html.git"
+    "url": "git://github.com/hal313/grunt-featureswitch-strip.git"
   },
   "bugs": {
-    "url": "https://github.com/hal313/grunt-featureswitch-html/issues"
+    "url": "https://github.com/hal313/grunt-featureswitch-strip/issues"
   },
   "licenses": [
     {
       "type": "MIT",
-      "url": "https://github.com/hal313/grunt-featureswitch-html/blob/master/LICENSE-MIT"
+      "url": "https://github.com/hal313/grunt-featureswitch-strip/blob/master/LICENSE-MIT"
     }
   ],
   "engines": {

--- a/tasks/featureswitch-strip.js
+++ b/tasks/featureswitch-strip.js
@@ -1,6 +1,6 @@
 /*
- * grunt-featureswitch-html
- * https://github.com/hal313/grunt-featureswitch-html
+ * grunt-featureswitch-strip
+ * https://github.com/hal313/grunt-featureswitch-strip
  *
  * Copyright (c) 2016 John Ghidiu
  * Licensed under the MIT license.
@@ -12,7 +12,7 @@ module.exports = function(grunt) {
 
   // TODO: Add option to silence the feature switch summary
 
-  grunt.registerMultiTask('featureswitch-html', 'Removes disabled features from HTML', function() {
+  grunt.registerMultiTask('featureswitch-strip', 'Removes disabled features from HTML', function() {
     var options = this.options({
       includeHTML: true,
       includeJS: false

--- a/test/featureswitch-strip_test.js
+++ b/test/featureswitch-strip_test.js
@@ -23,15 +23,13 @@
    test.ifError(value)
    */
 
-  exports['featureswitch-html'] = {
+  exports['featureswitch-strip'] = {
     setUp: function(done) {
       // Setup here if necessary
       done();
     },
 
     'simple-html-only-disabled': function(test) {
-      test.expect(1);
-
       var actual = grunt.file.read('test/actual/simple-html-only-disabled.html');
       var expected = grunt.file.read('test/expected/simple-html-only-disabled.html');
 
@@ -40,8 +38,6 @@
       test.done();
     },
     'simple-html-only-enabled': function(test) {
-      test.expect(1);
-
       var actual = grunt.file.read('test/actual/simple-html-only-enabled.html');
       var expected = grunt.file.read('test/expected/simple-html-only-enabled.html');
 
@@ -60,8 +56,6 @@
       test.done();
     },
     'simple-js-only-enabled': function(test) {
-      test.expect(1);
-
       var actual = grunt.file.read('test/actual/simple-js-only-enabled.js');
       var expected = grunt.file.read('test/expected/simple-js-only-enabled.js');
 


### PR DESCRIPTION
- Renamed package from grunt-featureswitch-html to grunt-featureswitch-strip.
- Enhanced README.md to better capture concepts and provide examples.


